### PR TITLE
Fixed broken QueryPlanner.scala link

### DIFF
--- a/documentation/2.0.0-m.1/user/accumulo/internals.html
+++ b/documentation/2.0.0-m.1/user/accumulo/internals.html
@@ -189,7 +189,7 @@
 <h1>8.11. Internals<a class="headerlink" href="#internals" title="Permalink to this headline">¶</a></h1>
 <div class="section" id="indexing-strategies">
 <h2>8.11.1. Indexing Strategies<a class="headerlink" href="#indexing-strategies" title="Permalink to this headline">¶</a></h2>
-<p>For details on how GeoMesa chooses and executes queries, see the <a class="reference external" href="https://github.com/locationtech/geomesa/blob/master/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/QueryPlanner.scala">QueryPlanner</a> and
+<p>For details on how GeoMesa chooses and executes queries, see the <a class="reference external" href="https://github.com/locationtech/geomesa/blob/master/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryPlanner.scala">QueryPlanner</a> and
 <a class="reference external" href="https://github.com/locationtech/geomesa/blob/master/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/StrategyDecider.scala">StrategyDecider</a> classes in the <strong>geomesa-index-api</strong> project. The generic query
 planning API is configured for the Accumulo data store in the <a class="reference external" href="https://github.com/locationtech/geomesa/blob/master/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloQueryPlanner.scala">AccumuloQueryPlanner</a> class.</p>
 </div>


### PR DESCRIPTION
Not sure if you meant to reference api/QueryPlan.scala or planning/QueryPlanner.scala